### PR TITLE
Remove TwoPageRight

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -360,7 +360,6 @@
    %%%breaklinks=true,% set by hyperref based on driver
    colorlinks=true,%
    allcolors=black,%
-   pdfpagelayout=TwoPageRight,%
    pdfstartview=Fit%
 }
 \fi

--- a/lni.dtx
+++ b/lni.dtx
@@ -840,7 +840,6 @@ This work consists of the file  lni.dtx
    %%%breaklinks=true,% set by hyperref based on driver
    colorlinks=true,%
    allcolors=black,%
-   pdfpagelayout=TwoPageRight,%
    pdfstartview=Fit%
 }
 \fi


### PR DESCRIPTION
The hyperref optoin `TwoPageRight` is more annoying than helping. I would just leave it out, because I once had also issues with `SinglePage`. 