### PR TITLE
Small improvements

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -44,7 +44,10 @@
 \DeclareOption*{\ClassWarning{Option `\CurrentOption` is not supported!}}
 \ProcessOptions\relax
 
+\iflnienglish
+\else
 \RequirePackage[ngerman=ngerman-x-latest]{hyphsubst}
+\fi
 \LoadClass[10pt,twoside,a4paper,fleqn]{article}
 \RequirePackage{cmap}
 \RequirePackage{inputenc}
@@ -109,7 +112,7 @@
 \def\@@title[#1]#2{\gdef\@shorttitle{#1}\gdef\@title{#2}}
 
 \renewcommand{\author}{\@dblarg\@@author}
-\def\@@author[#1]#2{\gdef\@shortauthor{{\let\footnote\@gobble\def\and{\unskip\ \andname\ }#1}}\gdef\@author{#2}}
+\def\@@author[#1]#2{\gdef\@shortauthor{{\let\footnote\@gobble\def\and{\unskip,\ }#1}}\gdef\@author{#2}}
 
 \newcommand*{\email}[1]{{\urlstyle{same}\protect\url{#1}}}
 
@@ -177,7 +180,7 @@
 }{\endquotation}
 
 \newenvironment{keywords}{\fontsize{9}{10}\selectfont
-    \noindent{\bfseries Keywords:}}{}
+    \noindent{\bfseries Keywords:\ }}{}
 
 \renewcommand{\section}{\@startsection{section}{1}{\z@}%
   {-16\p@ \@plus -4\p@ \@minus -4\p@}{5\p@ \@plus 4\p@ \@minus 4\p@}{\fontsize{12}{14}\fontseries{b}\selectfont}}
@@ -226,6 +229,8 @@
                 \@dblfloat{table}}
                {\end@dblfloat}
 
+\RequirePackage[font=small]{caption}
+
 \setlength{\mathindent}{0.5cm}
 
 \RequirePackage{verbatim}
@@ -259,6 +264,7 @@
        \setlength{\parsep}{-2pt}}%
        %\setlength{\itemindent}{0.5cm}
   \fi}
+\renewcommand\labelitemi{$\bullet$}
 
   % Nummierierte Aufzählung
   \renewcommand{\labelenumii}{\alph{enumii})}
@@ -366,7 +372,7 @@
 \fi
 \RequirePackage[all]{hypcap}
 
-\def\and{\unskip\,}
+\def\and{\unskip\hspace{-.42em},\hspace{.6em}}
 
 \iflnienglish
    \bibliographystyle{lni}

--- a/lni.dtx
+++ b/lni.dtx
@@ -485,7 +485,10 @@ This work consists of the file  lni.dtx
 \DeclareOption*{\ClassWarning{Option `\CurrentOption` is not supported!}}
 \ProcessOptions\relax
 
+\iflnienglish
+\else
 \RequirePackage[ngerman=ngerman-x-latest]{hyphsubst}
+\fi
 \LoadClass[10pt,twoside,a4paper,fleqn]{article}
 \RequirePackage{cmap}
 \RequirePackage{inputenc}
@@ -559,7 +562,7 @@ This work consists of the file  lni.dtx
 \def\@@title[#1]#2{\gdef\@shorttitle{#1}\gdef\@title{#2}}
 
 \renewcommand{\author}{\@dblarg\@@author}
-\def\@@author[#1]#2{\gdef\@shortauthor{{\let\footnote\@gobble\def\and{\unskip\ \andname\ }#1}}\gdef\@author{#2}}
+\def\@@author[#1]#2{\gdef\@shortauthor{{\let\footnote\@gobble\def\and{\unskip,\ }#1}}\gdef\@author{#2}}
 
 \newcommand*{\email}[1]{{\urlstyle{same}\protect\url{#1}}}
 
@@ -632,7 +635,7 @@ This work consists of the file  lni.dtx
 
 % Keywords
 \newenvironment{keywords}{\fontsize{9}{10}\selectfont
-    \noindent{\bfseries Keywords:}}{}
+    \noindent{\bfseries Keywords:\ }}{}
 
 % Überschriften
 \renewcommand{\section}{\@startsection{section}{1}{\z@}%
@@ -688,6 +691,8 @@ This work consists of the file  lni.dtx
                 \@dblfloat{table}}
                {\end@dblfloat}
 
+\RequirePackage[font=small]{caption}
+
 % Gleichungen mit richtiger Einrückung, 0.5cm
 % fleqn-Option oben
 \setlength{\mathindent}{0.5cm}
@@ -729,7 +734,8 @@ This work consists of the file  lni.dtx
        \setlength{\parsep}{-2pt}}%
        %\setlength{\itemindent}{0.5cm}
   \fi}
-  
+\renewcommand\labelitemi{$\bullet$}
+
   % Nummierierte Aufzählung
   \renewcommand{\labelenumii}{\alph{enumii})}
   \renewcommand*\enumerate{%    
@@ -849,7 +855,7 @@ This work consists of the file  lni.dtx
 %    \begin{macrocode}
 \RequirePackage[all]{hypcap}
 
-\def\and{\unskip\,}
+\def\and{\unskip\hspace{-.42em},\hspace{.6em}}
 
 \iflnienglish
    \bibliographystyle{lni}


### PR DESCRIPTION
- `\and` - implements fix for #8
- Caption font size - fix for #10
- Space after `keywords:`
- Fix bullet of itemize - fix for #9
- German hyphenation only for German documents