### PR TITLE
Remove explicit input encoding for bibliography

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -282,7 +282,6 @@
 
 \renewenvironment{thebibliography}[1]
      {\iflnienglish\selectlanguage{english}\else\selectlanguage{ngerman}\fi
-      \inputencoding{latin1}
       \section*{\refname}%
       \bgroup\fontsize{9}{10}\selectfont
       \list{\@biblabel{\@arabic\c@enumiv}}%
@@ -300,7 +299,7 @@
       \sfcode`\.\@m}
      {\def\@noitemerr
        {\@latex@warning{Empty `thebibliography' environment}}%
-      \endlist\egroup\inputencoding{utf8}}
+      \endlist\egroup}
 
 \RequirePackage{graphicx}
 \RequirePackage{fancyhdr}


### PR DESCRIPTION
The template explicitly sets `latin1` for input encoding of the bibliography. Unrelated to the package options `utf8`, `latin1`, or `ansinew`.

I assume that the bibliography should be encoded in the same encoding as the original tex file.

If not, the user should be able to specify the encoding by himself.