### PR TITLE
Scale newtxtt

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -58,7 +58,7 @@
 
 \RequirePackage{newtxtext}
 \RequirePackage{newtxmath}
-\RequirePackage[zerostyle=b,straightquotes]{newtxtt}
+\RequirePackage[zerostyle=b,straightquotes,scaled=.9]{newtxtt}
 \RequirePackage[final,tracking=smallcaps,expansion=alltext,protrusion=true]{microtype}%
 \SetTracking{encoding=*,shape=sc}{50}%
 \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts

--- a/lni.dtx
+++ b/lni.dtx
@@ -498,7 +498,7 @@ This work consists of the file  lni.dtx
 % Define a modern variant of Times as the main font
 \RequirePackage{newtxtext}
 \RequirePackage{newtxmath}
-\RequirePackage[zerostyle=b,straightquotes]{newtxtt}
+\RequirePackage[zerostyle=b,straightquotes,scaled=.9]{newtxtt}
 \RequirePackage[final,tracking=smallcaps,expansion=alltext,protrusion=true]{microtype}%
 \SetTracking{encoding=*,shape=sc}{50}%
 \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts


### PR DESCRIPTION
Altough the manual of newtxtt reads that there is no scaling necessary, the font reads too large:

![large](https://cloud.githubusercontent.com/assets/1366654/22009177/90059214-dc81-11e6-98ac-9b9fd2d4443e.png)

When using the patch, it renders as follows:

![grabbed_20170117-065303](https://cloud.githubusercontent.com/assets/1366654/22009186/9d7aa11e-dc81-11e6-9c73-960c9cd672c3.png)

This was my MWE:

```
\documentclass[english]{lni}

\usepackage{mwe}

\lstset{
  language=SQL,
  basicstyle=\normalsize\ttfamily,
  showstringspaces=false
}

\begin{document}
\title{title}

\blindtext{}
And some more text with an SQL statement \lstinline!select * from MyTable;! without any further meaning.
\blindtext{}

\begin{lstlisting}
select Name, Total
from Professors, (select sum(ECTS) as Total
                  from Courses
                  where PersId = Lecturer) C
\end{lstlisting}

\blindtext{}

\end{document}

```
