### PR TITLE
Prevent comma flowing outside

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -338,7 +338,7 @@
 }%
 \fancypagestyle{plain}{%
    \fancyhead{} % Löscht alle Kopfzeileneinstellungen
-   \fancyhead[RO]{\small\@editor~(Hrsg.):\ \@booktitle,\linebreak Lecture Notes in Informatics (LNI), Gesellschaft für Informatik, Bonn~\@year \hspace{5pt}\thepage\hspace{0.05cm}}
+   \fancyhead[RO]{\small\@editor~(Hrsg.):\ \@booktitle,\hspace{0.000001pt}\null\linebreak Lecture Notes in Informatics (LNI), Gesellschaft für Informatik, Bonn~\@year \hspace{5pt}\thepage\hspace{0.05cm}}
    \fancyfoot{} % Löscht alle Fußzeileneinstellungen
    \renewcommand{\headrulewidth}{0.4pt} %Linie unter Kopfzeile
 }

--- a/lni.dtx
+++ b/lni.dtx
@@ -813,7 +813,7 @@ This work consists of the file  lni.dtx
 %    \begin{macrocode}
 \fancypagestyle{plain}{%
    \fancyhead{} % Löscht alle Kopfzeileneinstellungen
-   \fancyhead[RO]{\small\@editor~(Hrsg.):\ \@booktitle,\linebreak Lecture Notes in Informatics (LNI), Gesellschaft für Informatik, Bonn~\@year \hspace{5pt}\thepage\hspace{0.05cm}}
+   \fancyhead[RO]{\small\@editor~(Hrsg.):\ \@booktitle,\hspace{0.000001pt}\null\linebreak Lecture Notes in Informatics (LNI), Gesellschaft für Informatik, Bonn~\@year \hspace{5pt}\thepage\hspace{0.05cm}}
    \fancyfoot{} % Löscht alle Fußzeileneinstellungen
    \renewcommand{\headrulewidth}{0.4pt} %Linie unter Kopfzeile 
 }


### PR DESCRIPTION
I really like microtype. Sometimes, its effects are unwanted. In the title, the comma noticeably flows outside the page margin:

![grabbed_20170117-070211](https://cloud.githubusercontent.com/assets/1366654/22009423/702f28ae-dc83-11e6-9727-e93fe8f356c2.png)

I tried with a local `protrusion=false`, but it didn't work out. Therefore, I made a hack using `\hspace` and `\null`:

![grabbed_20170117-070348](https://cloud.githubusercontent.com/assets/1366654/22009422/6c849234-dc83-11e6-9d01-0f504c1f1b03.png)

Code to reproduce:

```
\documentclass[english]{lni}

\usepackage{mwe}

\begin{document}
\title{title}
\author{author}

\startpage{3}

\maketitle

\blindtext[25]{}

\end{document}
```

