### PR TITLE
Adapt the margins according to GI's requirements

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -15,8 +15,6 @@
 \NeedsTeXFormat{LaTeX2e}[1999/12/01]
 \ProvidesClass{lni}
     [2016/07/04 v1.0 A class for submissions to the ``Lecture Notes in Informatics'']
-\setlength{\hoffset}{-0,2cm}% correct left margin to 4.2cm
-\setlength{\voffset}{2.60cm}% correct top margin to 5.25cm
 \def\@clearglobaloption#1{%
   \def\@tempa{#1}%
   \def\@tempb{\@gobble}%
@@ -74,13 +72,14 @@
   <12->   MnSymbolC12%
 }{}
 \DeclareMathSymbol{\powerset}{\mathord}{MnSyC}{180}
-\setlength{\textheight}{19.2cm}
-\setlength{\headheight}{20.39pt}
-\setlength{\textwidth}{12.6cm}
-\setlength{\topmargin}{0.17cm}%
-\setlength{\oddsidemargin}{1.85cm}% korrigierte twoside werte
-\setlength{\evensidemargin}{1.85cm}% korrigierte twoside werte
-\setlength{\headsep}{0.31cm}%
+\usepackage[
+  a4paper,
+  total={12.6cm,19.2cm},
+  includehead,
+  headheight=20.39pt,
+  headsep=.31cm,
+  centering]
+  {geometry}
 
 \def\thisbottomragged{\def\@textbottom{\vskip\z@ plus.0001fil
 \global\let\@textbottom\relax}}

--- a/lni.dtx
+++ b/lni.dtx
@@ -452,11 +452,7 @@ This work consists of the file  lni.dtx
 %    \begin{macrocode}
 %<*class>
 %    \end{macrocode}
-% Satzspiegelposition gemäß LNI-Herausgeberrichtlinien (Korrektur von 
-%Thomas.Kuehne@mcs.vuw.ac.nz)
 %    \begin{macrocode}
-\setlength{\hoffset}{-0,2cm}% correct left margin to 4.2cm
-\setlength{\voffset}{2.60cm}% correct top margin to 5.25cm
 %
 \def\@clearglobaloption#1{%
   \def\@tempa{#1}%
@@ -522,13 +518,14 @@ This work consists of the file  lni.dtx
 %    \end{macrocode}
 % Satzspiegel
 %    \begin{macrocode}
-\setlength{\textheight}{19.2cm}
-\setlength{\headheight}{20.39pt}
-\setlength{\textwidth}{12.6cm}
-\setlength{\topmargin}{0.17cm}%
-\setlength{\oddsidemargin}{1.85cm}% korrigierte twoside werte
-\setlength{\evensidemargin}{1.85cm}% korrigierte twoside werte
-\setlength{\headsep}{0.31cm}%
+\usepackage[
+  a4paper,
+  total={12.6cm,19.2cm},
+  includehead,
+  headheight=20.39pt,
+  headsep=.31cm,
+  centering]
+  {geometry}
 
 % Ragged bottom -- verhindert die Ausdehnung der Seite = Veränderung der Abstände
 \def\thisbottomragged{\def\@textbottom{\vskip\z@ plus.0001fil


### PR DESCRIPTION
This PR adapts the margins according to GI's requirements.

> Der Satzspiegel beträgt 19,2 x 12,6 cm

The page format stays A4 even though GI requires "23,5 x 15,5 cm". Reason: The old template and the Word template also use A4 as basis.

This PR also fixes https://github.com/sieversMartin/LNI/issues/22.

Here a screenshot before this fix. Left: Word; Right: LaTeX

![image001](https://cloud.githubusercontent.com/assets/1366654/22442922/4a55a94a-e73d-11e6-87aa-183e4cb4c535.jpg)
