### PR TITLE
Switch to microtype default options

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -59,7 +59,7 @@
 \RequirePackage{newtxtext}
 \RequirePackage{newtxmath}
 \RequirePackage[zerostyle=b,straightquotes,scaled=.9]{newtxtt}
-\RequirePackage[final,tracking=smallcaps,expansion=alltext,protrusion=true]{microtype}%
+\RequirePackage{microtype}%
 \SetTracking{encoding=*,shape=sc}{50}%
 \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
 \DeclareFontFamily{U}{MnSymbolC}{}

--- a/lni.dtx
+++ b/lni.dtx
@@ -501,7 +501,7 @@ This work consists of the file  lni.dtx
 \RequirePackage{newtxtext}
 \RequirePackage{newtxmath}
 \RequirePackage[zerostyle=b,straightquotes,scaled=.9]{newtxtt}
-\RequirePackage[final,tracking=smallcaps,expansion=alltext,protrusion=true]{microtype}%
+\RequirePackage{microtype}%
 \SetTracking{encoding=*,shape=sc}{50}%
 \UseMicrotypeSet[protrusion]{basicmath} % disable protrusion for tt fonts
 %    \end{macrocode}


### PR DESCRIPTION
With the tuned microtype settings, the monospaced text flows too wide leading to issues when reformatting a paper:

left: default settings; right: tuned settings

![grabbed_20170306-122913](https://cloud.githubusercontent.com/assets/1366654/23608414/82b2d4f6-0269-11e7-91a2-512d07715de7.png)

This PR switches back to the default microtype settings.