### PR TITLE
enable "= as dashes

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -56,6 +56,8 @@
 \else
    \RequirePackage[english,ngerman]{babel}
 \fi
+\useshorthands*{"}
+\addto\extrasenglish{\languageshorthands{ngerman}}
 \RequirePackage{newtxtext}
 \RequirePackage{newtxmath}
 \RequirePackage[zerostyle=b,straightquotes,scaled=.9]{newtxtt}

--- a/lni.dtx
+++ b/lni.dtx
@@ -589,6 +589,9 @@ This work consists of the file  lni.dtx
 \else
    \RequirePackage[english,ngerman]{babel}
 \fi
+%Hint by http://tex.stackexchange.com/a/321067/9075 -> enable "= as dashes
+\useshorthands*{"}
+\addto\extrasenglish{\languageshorthands{ngerman}}
 %    \end{macrocode}
 % Define a modern variant of Times as the main font
 %    \begin{macrocode}


### PR DESCRIPTION
Sometimes, users want to hyphenate words with a dash inside. In normal tex settings, this is not possible. This PR enables the babel shorthands wo write `pro"=longed` words, which can be hyphenated at any place and not only at the dash.