### PR TITLE
Enable biblatex by using biblatex package

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -87,7 +87,11 @@
   {geometry}
 \RequirePackage[autostyle]{csquotes}
 \ifusebiblatex
-   \RequirePackage{biblatex-lni}%
+  \RequirePackage[
+    backend=biber, % UTF-8 support
+    style=LNI,     % The GI style - see https://www.ctan.org/pkg/biblatex-lni
+    natbib=true    % Required for \Citet
+  ]{biblatex}[2016-09-15] %at least version 3.6 of biblatex is required.
 \fi%
 \RequirePackage{graphicx}
 \RequirePackage{grffile}

--- a/lni.dtx
+++ b/lni.dtx
@@ -631,7 +631,11 @@ This work consists of the file  lni.dtx
 %    \begin{macrocode}
 \RequirePackage[autostyle]{csquotes}
 \ifusebiblatex
-   \RequirePackage{biblatex-lni}%
+  \RequirePackage[
+    backend=biber, % UTF-8 support
+    style=LNI,     % The GI style - see https://www.ctan.org/pkg/biblatex-lni
+    natbib=true    % Required for \Citet
+  ]{biblatex}[2016-09-15] %at least version 3.6 of biblatex is required.
 \fi%
 %    \end{macrocode}
 %    \begin{macrocode}


### PR DESCRIPTION
As far as I understand biblatex, styles have to included as parameters to the `biblatex` package. If I compile the current version, I get following output

    ! LaTeX Error: File `biblatex-lni.sty' not found.

With the patch, the document compiles fine.

It is debatable whether `biber` should be enforced though.