### PR TITLE
Make link clickable in SumatraPDF

### DIFF
--- a/lni.dtx
+++ b/lni.dtx
@@ -343,7 +343,7 @@ This work consists of the file  lni.dtx
 % \section{Installation}
 % The \lni{} bundle is distributed via 
 % \href{https://github.com/sieversMartin/LNI}{Github} and 
-% \href{www.ctan.org}{CTAN}. The later is the basis for all updates of the two 
+% \href{https://www.ctan.org}{CTAN}. The later is the basis for all updates of the two
 % main \TeX{} distributions \MiKTeX{} and 
 % \TeX{}~Live. Thus the easiest way to get all files needed to typeset an 
 % article for the \LNI{} is to use the package manager for your distribution.


### PR DESCRIPTION
Sumatra needs the protocol prefix. This PR adds it.