### PR TITLE
Spell GitHub as "GitHub"

### DIFF
--- a/lni.dtx
+++ b/lni.dtx
@@ -342,7 +342,7 @@ This work consists of the file  lni.dtx
 % 
 % \section{Installation}
 % The \lni{} bundle is distributed via 
-% \href{https://github.com/sieversMartin/LNI}{Github} and 
+% \href{https://github.com/sieversMartin/LNI}{GitHub} and
 % \href{www.ctan.org}{CTAN}. The later is the basis for all updates of the two 
 % main \TeX{} distributions \MiKTeX{} and 
 % \TeX{}~Live. Thus the easiest way to get all files needed to typeset an 
@@ -535,7 +535,7 @@ This work consists of the file  lni.dtx
 %
 % \section{Bugs and feature request}
 % If you find a bug or have a feature request, please open an ``issue'' at the
-% Github website.
+% \href{https://github.com/sieversMartin/LNI/issues}{GitHub website}.
 %
 % \StopEventually{^^A
 %  \PrintChanges


### PR DESCRIPTION
This spells GitHub in the way suggested by https://de.wikipedia.org/wiki/GitHub. A direct link to the issues page is added.