### PR TITLE
Enable hyperlinked authors at \citeauthor

### DIFF
--- a/lni.cls
+++ b/lni.cls
@@ -94,6 +94,18 @@
     style=LNI,     % The GI style - see https://www.ctan.org/pkg/biblatex-lni
     natbib=true    % Required for \Citet
   ]{biblatex}[2016-09-15] %at least version 3.6 of biblatex is required.
+  % Enable hyperlinked authors when using \citeauthor
+  % Source: http://tex.stackexchange.com/a/75916/9075
+  \DeclareCiteCommand{\citeauthor}%
+    {\boolfalse{citetracker}%
+     \boolfalse{pagetracker}%
+     \usebibmacro{prenote}}%
+    {\ifciteindex%
+       {\indexnames{labelname}}%
+       {}%
+     \printtext[bibhyperref]{\printnames{labelname}}}%
+    {\multicitedelim}%
+    {\usebibmacro{postnote}}%
 \fi%
 \RequirePackage{graphicx}
 \RequirePackage{grffile}

--- a/lni.dtx
+++ b/lni.dtx
@@ -642,6 +642,18 @@ This work consists of the file  lni.dtx
     style=LNI,     % The GI style - see https://www.ctan.org/pkg/biblatex-lni
     natbib=true    % Required for \Citet
   ]{biblatex}[2016-09-15] %at least version 3.6 of biblatex is required.
+  % Enable hyperlinked authors when using \citeauthor
+  % Source: http://tex.stackexchange.com/a/75916/9075
+  \DeclareCiteCommand{\citeauthor}%
+    {\boolfalse{citetracker}%
+     \boolfalse{pagetracker}%
+     \usebibmacro{prenote}}%
+    {\ifciteindex%
+       {\indexnames{labelname}}%
+       {}%
+     \printtext[bibhyperref]{\printnames{labelname}}}%
+    {\multicitedelim}%
+    {\usebibmacro{postnote}}%
 \fi%
 %    \end{macrocode}
 %    \begin{macrocode}


### PR DESCRIPTION
Reading http://tex.stackexchange.com/a/75916/907, the authors of `\citeauthor` are not hyperlinked at the biblatex case. This adds support for hyperlinked authors.