### PR TITLE
Ensure that lni.pdf has no undefined references

### DIFF
--- a/prepare_for_CTAN
+++ b/prepare_for_CTAN
@@ -5,6 +5,8 @@
 #
 echo "Make sure we have the latest version"
 pdflatex lni.dtx
+echo "Make sure all links in lni.pdf are correct"
+pdflatex lni.dtx
 if [ -f lni.tar.gz ]; then
    echo "Remove old archive"
    rm lni.tar.gz


### PR DESCRIPTION
This adds a second pdflatex run to ensure that there are no undefined references in `lni.pdf`.

Reason: One might start with a repository which was cleaned using `git clean -xdf`. Then, after `prepare_for_CTAN` run, `lni.pdf` has broken references.