### PR TITLE
Add section "trouble shooting"

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ It is based on previous templates created on behalf of the GI.
 
 Stable versions are always uploaded to CTAN. In addition you'll find the most
 recent developer version on GitHub at <https://github.com/sieversMartin/lni>.
+The most recent documentation is available at
+<https://github.com/sieversMartin/LNI/blob/master/lni.pdf>. It includes a short
+description how to use the template and also provides trouble shooting hints.
 
 Please note, that this is not yet an official release!
 

--- a/lni.dtx
+++ b/lni.dtx
@@ -593,6 +593,32 @@ This work consists of the file  lni.dtx
 % \end{document}
 % \end{examplecode}
 %
+%
+% \section{Trouble shooting}
+% This section lists the most common issues when using this template. For more
+% help, please head to
+% \href{https://github.com/egeerardyn/awesome-LaTeX/blob/master/README.md}%
+% {the awesome LaTeX list}.
+%
+% If the compiler error is \texttt{! pdfTeX error (font expansion): auto
+% expansion is onlypossible with scalable fonts.}, the you have to install the
+% \pkg{cm-super} package. Afterwards, run \texttt{initexmf --mkmaps} on the
+% command line. A longer discussion is available at
+% \url{http://tex.stackexchange.com/a/324972/9075}.
+%
+% If the compiler error is ``\texttt{! LaTeX Error: Command \textbackslash
+% openbox already defined.}'', insert \cs{let}\cs{openbox}\cs{relax} before
+% \cs{usepackage\{amsthm\}}.
+%
+% If the compiler error is ``\texttt{! Undefined control sequence. l.84
+% \textbackslash ulp@afterend}'', just clean up (remove \texttt{paper.aux})
+% and recompile.
+%
+% If the compiler error is ``\texttt{! Package xkeyval Error: 'family\_i'
+% undefined in families blx@opt@namepart'.}'', it is an indicator that you
+% switched from bibtex to biblatex. Clean up (remove \texttt{paper.bbl})
+% and recompile.
+%
 % \section{Bugs and feature request}
 % If you find a bug or have a feature request, please open an ``issue'' at the
 % \href{https://github.com/sieversMartin/LNI/issues}{GitHub website}.


### PR DESCRIPTION
This PR adds a section "touble shooting" based on https://github.com/latextemplates/LNI/blob/master/README.md#trouble-shooting. I chose to put it into `lni.pdf`, because core LaTeX users prefer that position.

It might be that occasional LaTeX users are not aware of good documentation of LaTeX packages and that the README.md would be a better place. To prevent that two places have to maintained, I added a simple text in the README.md pointing to the most recent documentation.