### PR TITLE
Add link to biblatex documentation

### DIFF
--- a/lni.dtx
+++ b/lni.dtx
@@ -576,7 +576,8 @@ This work consists of the file  lni.dtx
 %
 % If you want to pass settings to \pkg{biblatex} you can use a config 
 % file \texttt{biblatex.cfg}, for additional options please use the macro 
-% \cs{ExecuteBibliographyOptions}. Please consult the package's documentation for 
+% \cs{ExecuteBibliographyOptions}. Please consult the
+% \href{http://texdoc.net/pkg/biblatex}{package's documentation} for
 % more information.
 % \begin{examplecode}
 % % !TeX program = pdflatex


### PR DESCRIPTION
This adds a deep link to biblatex's documentation using the service provided by http://texdoc.net/