### PR TITLE
Add link to the GI website

### DIFF
--- a/lni.dtx
+++ b/lni.dtx
@@ -359,11 +359,12 @@ This work consists of the file  lni.dtx
 % 
 % \section{Installation}
 % The \lni{} bundle is currently distributed via 
-% \href{https://github.com/sieversMartin/LNI}{GitHub}, the GI website and
-% \href{https://www.ctan.org}{CTAN}. The later is the basis for all updates of the 
-% two main \TeX{} distributions \MiKTeX{} and 
-% \TeX{}~Live. Thus the easiest way to get all files needed to typeset an 
-% article for the \LNI{} is to use the package manager for your distribution.
+% \href{https://github.com/sieversMartin/LNI}{GitHub}, the
+% \href{https://www.gi.de/service/publikationen/lni/autorenrichtlinien.html}
+% {GI website} and \href{https://www.ctan.org}{CTAN}.
+% The later is the basis for all updates of the two main \TeX{} distributions
+% \MiKTeX{} and \TeX{}~Live. Thus the easiest way to get all files needed to typeset
+% an article for the \LNI{} is to use the package manager of your distribution.
 % 
 % For a manual installation you should copy all files (cls, tex, pdf and bst) to 
 % your local TEXMF tree and update your file name database.


### PR DESCRIPTION
This adds a link to https://www.gi.de/service/publikationen/lni/autorenrichtlinien.html to have all three textual references backed with a link

![grafik](https://cloud.githubusercontent.com/assets/1366654/24598992/7b5a1c8c-184e-11e7-80f8-77850409bb00.png)

Further, a small grammar thing (for your distribution -> of your distribution) was changed.