### PR TITLE
Add text of README.md to lni.dtx

### DIFF
--- a/lni.dtx
+++ b/lni.dtx
@@ -25,6 +25,9 @@ It is based on previous templates created on behalf of the GI.
 
 Stable versions are always uploaded to CTAN. In addition you'll find the most 
 recent developer version on GitHub at <https://github.com/sieversMartin/lni>.
+The most recent documentation is available at
+<https://github.com/sieversMartin/LNI/blob/master/lni.pdf>. It includes a short
+description how to use the template and also provides trouble shooting hints.
 
 Please note, that this is not yet an official release!
 


### PR DESCRIPTION
In #38, I just changed README.md, because I am used to change the README.md directly. However, in the LaTeX world, it seems that `dtx` is used for generation of **all** files.