### PR TITLE
Add quick start

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,17 @@ This is the official version of the class “lni” for submissions to the
 
 It is based on previous templates created on behalf of the GI.
 
+Quick start:
+Download [lni-author-template.tex](lni-author-template.tex) and edit it in your favorite LaTeX editor.
+You will have to use [bibtex](https://www.ctan.org/pkg/bibtex) as bibliography tool.
+In case you want to use [biblatex](https://www.ctan.org/pkg/biblatex), read on in the documentation of this class.
+
 Stable versions are always uploaded to CTAN (<https://www.ctan.org/pkg/lni>).
-In addition you'll find the most recent developer version on GitHub at <https://github.com/gi-ev/lni>.
+In addition you will find the most recent developer version on GitHub at <https://github.com/gi-ev/lni>.
 The most recent documentation is available at <https://github.com/gi-ev/LNI/blob/master/lni.pdf>.
 It includes a short description how to use the template and also provides trouble shooting hints.
 
-Please see CHANGELOG.md for a version history
+Please see [CHANGELOG.md](CHANGELOG.md) for a version history
 
   [GI]: https://www.gi.de/
   [Lecture Notes in Informatics]: https://www.gi.de/service/publikationen/lni.html


### PR DESCRIPTION
This adds an initial quick start. Aim: The information displayed at https://www.ctan.org/tex-archive/macros/latex/contrib/lni should be enough to start with the template without having to read the whole documentation.