### PR TITLE
Drop the keepalive workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -131,11 +131,3 @@ jobs:
         with:
           script: com.github.nbbrd.heylogs:heylogs-cli:0.9.2:bin
           scriptargs: "check CHANGELOG.md"
-  keepalive:
-    name: Keepalive
-    runs-on: ubuntu-latest
-    permissions:
-      actions: write
-    steps:
-      - uses: actions/checkout@v4
-      - uses: gautamkrishnar/keepalive-workflow@v2


### PR DESCRIPTION
The repository/action has been disabled by GitHub for violating the TOS.